### PR TITLE
SQL Injection leads to authentication bypass

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -38,7 +38,7 @@
   app.post('/', (req, res) => {
     let pwd = db.all("SELECT password FROM whitelist WHERE username = $name", 
     {
-      $name: ${req.body.username}
+      $name: req.body.username
     },
     (err, rows) => {
       if (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -36,7 +36,11 @@
 
 
   app.post('/', (req, res) => {
-    let pwd = db.all(`SELECT password FROM whitelist WHERE username = '${req.body.username}'`, (err, rows) => {
+    let pwd = db.all("SELECT password FROM whitelist WHERE username = $name", 
+    {
+      $name: ${req.body.username}
+    },
+    (err, rows) => {
       if (err) {
         throw err;
       }


### PR DESCRIPTION
Howdy! It's @dprk_ebooks@aus.social here.

I know it's super early days but I thought I'd offer a quick tip. Your login route builds a SQL query with string concatenation which causes an SQL injection vulnerability. Because the passwords aren't hashed, this leads to an authentication bypass as well.

To replicate the issue, try to log in with the password `foo` and the user `' UNION SELECT 'foo' as password WHERE '1'='1`. 

I've left password hashing out of scope, but I thought you might like an example of a parameterized SQL query which mitigates the SQL injection.

Hopefully you find this helpful but by all means tell me to go away if not.

Cheers!